### PR TITLE
Update RTD link

### DIFF
--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -16,7 +16,7 @@ commands =
 passenv =
     *
 {%- else -%}
-; a generative tox configuration, see: https://testrun.org/tox/en/latest/config.html#generative-envlist
+; a generative tox configuration, see: https://tox.readthedocs.io/en/latest/config.html#generative-envlist
 
 [tox]
 envlist =


### PR DESCRIPTION
https://testrun.org/ is just a squatted domain. Official docs are under https://tox.readthedocs.io/